### PR TITLE
Dev hf and exllama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ scripts/
 gpt-plan-benchmark/
 .DS_Store
 .vscode/
+dataset/
+*.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "exllama"]
+	path = exllama
+	url = https://github.com/turboderp/exllama.git

--- a/README.md
+++ b/README.md
@@ -16,6 +16,29 @@ Given any reasoning problem, simply define the reward function and an optional w
 
 - **Compatibility with any LLM libraries**: Our framework is compatible with any LLM frameworks, e.g. Huggingface transformers, OpenAI API, etc. Specifically, we integrated LLaMA with the option of using [fairscale](https://github.com/facebookresearch/llama) backend for improved multi-GPU performance or [LLaMA.cpp](https://github.com/ggerganov/llama.cpp) backend with lower hardware requirements.
 
+
+## Benchmarks
+We tested different reasoning algorithms on the following benchmarks (to be updated). For Tree-of-thoughts and Guided Decoding, we also list the results reported in their paper /  reproduced from their official repositories for reference (†). Some results are on the subsets of the first 100 examples (*).
+
+|Method|Base LLM|[GSM8K](https://arxiv.org/abs/2110.14168)|[AQuA](https://arxiv.org/abs/2008.12520)|[SVAMP](https://arxiv.org/abs/2103.07191)|[ASDiv](https://arxiv.org/abs/2106.15772)|[CommonsenseQA](https://arxiv.org/abs/1811.00937)|[StrategyQA](https://arxiv.org/abs/2101.02235)|
+|-|-|-|-|-|-|-|-|
+|[CoT](https://arxiv.org/abs/2201.11903)|LLaMA-33B|0.29|-|-|-|-|-|
+|CoT+[SC](https://arxiv.org/abs/2203.11171)|LLaMA-33B|0.47|-|-|-|-|-|
+|[Least-to-Most](https://arxiv.org/abs/2205.10625)+SC|LLaMA-33B|0.43|-|-|-|-|-|
+|[Guided Decoding](https://arxiv.org/abs/2305.00633)<sup>†</sup>|CodeX (PAL)|0.80|-|-|-|-|-|
+|Guided Decoding|CodeX (PAL)|[0.83\*](examples/guided_gsm8k)|-|-|-|-|-|
+|[RAP](https://arxiv.org/abs/2305.14992)|LLaMA-33B|0.49|-|-|-|-|-|
+|[RAP (aggr)](https://arxiv.org/abs/2305.14992)|LLaMA-33B|0.52|-|-|-|-|-|
+
+
+|Method|Base LLM|[Blocksworld](https://arxiv.org/abs/2305.15771)|[Game of 24](https://arxiv.org/abs/2305.10601)|[Mini Crosswords](https://arxiv.org/abs/2305.10601)|[ProntoQA](https://arxiv.org/abs/2210.01240)|
+|-|-|-|-|-|-|
+|CoT|LLaMA-33B|0.03|-|-|0.65|
+|[Tree-of-Thoughts](https://arxiv.org/abs/2305.10601)<sup>†</sup>|GPT-3.5-turbo|-|0.22|-|-|
+|Tree-of-Thoughts|GPT-3.5-turbo|-|[0.22](examples/tot_game24)|-|-|
+|RAP|LLaMA-33B|0.64|-|-|0.79|
+
+
 ## Understanding LLM Reasoners
 
 Consider the following problem:
@@ -217,29 +240,6 @@ cd llm-reasoners
 pip install -e .
 ```
 Note that some optional modules may need other dependencies. Please refer to the error message for details.
-
-## Benchmarks
-We tested different reasoning algorithms on the following benchmarks (to be updated). For Tree-of-thoughts and Guided Decoding, we also list the results reported in their paper /  reproduced from their official repositories for reference (†). Some results are on the subsets of the first 100 examples (*).
-
-|Method|Base LLM|[GSM8K](https://arxiv.org/abs/2110.14168)|[AQuA](https://arxiv.org/abs/2008.12520)|[SVAMP](https://arxiv.org/abs/2103.07191)|[ASDiv](https://arxiv.org/abs/2106.15772)|[CommonsenseQA](https://arxiv.org/abs/1811.00937)|[StrategyQA](https://arxiv.org/abs/2101.02235)|
-|-|-|-|-|-|-|-|-|
-|[CoT](https://arxiv.org/abs/2201.11903)|LLaMA-33B|0.29|-|-|-|-|-|
-|CoT+[SC](https://arxiv.org/abs/2203.11171)|LLaMA-33B|0.47|-|-|-|-|-|
-|[Least-to-Most](https://arxiv.org/abs/2205.10625)+SC|LLaMA-33B|0.43|-|-|-|-|-|
-|[Guided Decoding](https://arxiv.org/abs/2305.00633)<sup>†</sup>|CodeX (PAL)|0.80|-|-|-|-|-|
-|Guided Decoding|CodeX (PAL)|0.83\*|-|-|-|-|-|
-|[RAP](https://arxiv.org/abs/2305.14992)|LLaMA-33B|0.49|-|-|-|-|-|
-|[RAP (aggr)](https://arxiv.org/abs/2305.14992)|LLaMA-33B|0.52|-|-|-|-|-|
-
-
-|Method|Base LLM|[Blocksworld](https://arxiv.org/abs/2305.15771)|[Game of 24](https://arxiv.org/abs/2305.10601)|[Mini Crosswords](https://arxiv.org/abs/2305.10601)|[ProntoQA](https://arxiv.org/abs/2210.01240)|
-|-|-|-|-|-|-|
-|CoT|LLaMA-33B|0.03|-|-|0.65|
-|[Tree-of-Thoughts](https://arxiv.org/abs/2305.10601)<sup>†</sup>|GPT-3.5-turbo|-|0.22|-|-|
-|Tree-of-Thoughts|GPT-3.5-turbo|-|0.22|-|-|
-|RAP|LLaMA-33B|0.64|-|-|0.79|
-
-
 
 ## Citation
 This project is an extension of the following paper:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Given any reasoning problem, simply define the reward function and an optional w
 ## News
 - Aug. 10, 2023: Llama-2 is supported! You can run [examples](https://github.com/Ber666/llm-reasoners/tree/main/examples) with Llama-2 now.
 
+- Aug. 21, 2023: Huggingface api with bnb or awq quantization is supported now! Exllama with GPT-Q quantization is also supported now! You can now also deploy llama-2-70B with 2x24G GPUs. You can run [examples](https://github.com/Ber666/llm-reasoners/tree/main/examples).
+
 ## Why Choose LLM Reasoners?
 
 - **Cutting-Edge Reasoning Algorithms**: We offer the most up-to-date search algorithms for reasoning with LLMs, such as [RAP-MCTS](https://arxiv.org/abs/2305.14992), [Tree-of-Thoughts](https://arxiv.org/abs/2305.10601), [Guided Decoding](https://arxiv.org/abs/2305.00633), and more. These advanced algorithms enable tree-structure reasoning and outperform traditional chain-of-thoughts approaches.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,14 @@
 # Examples
+For exllama, please clone exllama repo under `llm-reasoners/` with `git clone https://github.com/turboderp/exllama.git`. And create an `__init.py__` with
+```
+from .generator import *
+from .cuda_ext import *
+from .model import *
+from .tokenizer import *
+from .lora import *
+```
+to solve dependency conflicts.
+
 
 ## GSM8K
 ### RAP
@@ -8,6 +18,11 @@ python -m torch.distributed.run --nproc_per_node 4 examples/rap_gsm8k/inference.
 for llama2
 ```bash
 CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.run --nproc_per_node 2 examples/rap_gsm8k/inference.py --llama_size "13B" --output_trace_in_each_iter --base_lm 'llama2'
+```
+for exllama and huggingface llama(params need to fill in inference.py)
+
+```bash
+CUDA_VISIBLE_DEVICES=0(,1) python examples/rap_gsm8k/inference.py
 ```
 ### PAL + Guided Beam Search
 
@@ -53,7 +68,10 @@ for llama2
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.run --nproc_per_node 8 examples/rap_blocksworld/inference.py --llama_size "70B" --data_path 'examples/rap_blocksworld/data/step_4.json' --depth_limit 4 --output_trace_in_each_iter
 ```
-
+for exllama and huggingface llama(params need to fill in inference.py)
+```bash
+CUDA_VISIBLE_DEVICES=0(,1) python examples/rap_blocksworld/inference.py
+```
 ## Game of 24
 > Note: You need to make a directory and put the game24 data in it. For example, examples/tot_game24/data/24.csv
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,8 @@
 
 ## GSM8K
 ### RAP
+user need to switch the main function for Fire()
+
 ```bash
 python -m torch.distributed.run --nproc_per_node 4 examples/rap_gsm8k/inference.py --llama_size "30B" --output_trace_in_each_iter
 ```
@@ -10,11 +12,17 @@ for llama2
 ```bash
 CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.run --nproc_per_node 2 examples/rap_gsm8k/inference.py --llama_size "13B" --output_trace_in_each_iter --base_lm 'llama2'
 ```
-for exllama and huggingface llama(params need to fill in inference.py)
 
+for exllama
 ```bash
-CUDA_VISIBLE_DEVICES=0(,1) python examples/rap_gsm8k/inference.py
+CUDA_VISIBLE_DEVICES=0 python examples/rap_gsm8k/inference.py --model_dir 'path/to/model/dir' --lora_dir None --batch_size 1 --output_trace_in_each_iter
 ```
+
+for huggingface llama
+```bash
+CUDA_VISIBLE_DEVICES=0 python examples/rap_gsm8k/inference.py --hf_path 'path/to/hf/model/dir' --peft_path None --batch_size 1 --quantized 'nf4' --output_trace_in_each_iter
+```
+
 ### PAL + Guided Beam Search
 
 > Note: You need to apply for the [research access](https://openai.com/form/researcher-access-program) to `Codex` (`code-davinci-002`) to run this approach
@@ -59,9 +67,17 @@ for llama2
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.run --nproc_per_node 8 examples/rap_blocksworld/inference.py --llama_size "70B" --data_path 'examples/rap_blocksworld/data/step_4.json' --depth_limit 4 --output_trace_in_each_iter
 ```
-for exllama and huggingface llama(params need to fill in inference.py)
+
+for exllama
+
 ```bash
-CUDA_VISIBLE_DEVICES=0(,1) python examples/rap_blocksworld/inference.py
+CUDA_VISIBLE_DEVICES=0 python examples/rap_blocksworld/inference.py --data_path 'examples/rap_blocksworld/data/step_4.json' --depth_limit 4 --model_dir 'path/to/model/dir' --lora_dir None --batch_size 1 --output_trace_in_each_iter
+```
+
+for huggingface llama
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python examples/rap_blockworld/inference.py -data_path 'examples/rap_blocksworld/data/step_4.json' --depth_limit 4 --hf_path 'path/to/hf/model/dir' --peft_path None --batch_size 1 --quantized 'nf4' --output_trace_in_each_iter
 ```
 ## Game of 24
 > Note: You need to make a directory and put the game24 data in it. For example, examples/tot_game24/data/24.csv

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,4 @@
 # Examples
-For exllama, please clone exllama repo under `llm-reasoners/` with `git clone https://github.com/turboderp/exllama.git`. And create an `__init.py__` with
-```
-from .generator import *
-from .cuda_ext import *
-from .model import *
-from .tokenizer import *
-from .lora import *
-```
-to solve dependency conflicts.
 
 
 ## GSM8K

--- a/examples/rap_blocksworld/inference.py
+++ b/examples/rap_blocksworld/inference.py
@@ -80,7 +80,6 @@ def rap_bw(base_model: LanguageModel,
 if __name__ == '__main__':
     import os
     import sys
-    sys.path.append('/data/haotian/RAP_tune/llm-reasoners/exllama')
     import json
     import warnings
     import fire
@@ -88,13 +87,11 @@ if __name__ == '__main__':
     import torch
     import torch.backends.cudnn
     from reasoners.lm import LLaMAModel, LlamaModel
-
     np.random.seed(1)
     random.seed(1)
     torch.manual_seed(1)
     torch.cuda.manual_seed(1)
     torch.backends.cudnn.deterministic = True
-
     def llama_main(llama_size: str = '13B',
              prompt_path: str = 'examples/rap_blocksworld/prompts/prompt.json',
              data_path: str = 'examples/rap_blocksworld/data/step_4.json',
@@ -155,13 +152,15 @@ if __name__ == '__main__':
             domain_file: str = "examples/rap_blocksworld/data/generated_domain.pddl",
             lm_plan_file: str = 'lm_plan.tmp',
             depth_limit: int = 6,
+            quantized = "nf4", # awq, int8, fp4, nf4, None
+            load_awq_pth = None,
             **kwargs
             ):
         from reasoners.lm import HFModel #maybe other transformer models also support, we have not check that
         with open(prompt_path) as f:
             prompt = json.load(f)
         device = torch.device("cuda:0")
-        llama_model = HFModel(llama_path, llama_path, device=device, max_batch_size=1, max_new_tokens=512, quantized="nf4", peft_pth=peft_path)
+        llama_model = HFModel(llama_path, llama_path, device=device, max_batch_size=1, max_new_tokens=512, quantized=quantized, peft_pth=peft_path, load_awq_pth=load_awq_pth)
         rap_bw(llama_model,
                prompt,
                disable_log=disable_log,
@@ -181,13 +180,16 @@ if __name__ == '__main__':
             domain_file: str = "examples/rap_blocksworld/data/generated_domain.pddl",
             lm_plan_file: str = 'lm_plan.tmp',
             depth_limit: int = 6,
+            batch_size: int = 1,
+            mem_map = None,
             **kwargs
             ):
+        print(model_dir)
         from reasoners.lm import ExLlamaModel  ##maybe other transformer models also support
         with open(prompt_path) as f:
             prompt = json.load(f)
         device = torch.device("cuda:0")
-        llama_model = ExLlamaModel(model_dir, lora_dir, device=device, max_batch_size=4, max_new_tokens=1024, max_seq_length=2048)
+        llama_model = ExLlamaModel(model_dir, lora_dir, device=device, max_batch_size=batch_size, max_new_tokens=1024, max_seq_length=2048, mem_map=mem_map)#please set mem_map if you need model parallelism, e.g. mem_map = [16,22] with 2 GPUs
         rap_bw(llama_model,
                prompt,
                disable_log=disable_log,
@@ -195,7 +197,8 @@ if __name__ == '__main__':
                config_file=config_file,
                domain_file=domain_file,
                depth_limit=depth_limit,
-               lm_plan_file=lm_plan_file, **kwargs)
+               lm_plan_file=lm_plan_file,
+               batch_size=batch_size, **kwargs)
     
     def llama2_main(llama_size: str = '70B',
              prompt_path: str = 'examples/rap_blocksworld/prompts/prompt.json',
@@ -222,5 +225,5 @@ if __name__ == '__main__':
                depth_limit=depth_limit,
                lm_plan_file=lm_plan_file, **kwargs)
 
-
-    fire.Fire(exllama_main())
+  
+    fire.Fire(exllama_main)#user still need to switch the model in the code

--- a/examples/rap_blocksworld/inference.py
+++ b/examples/rap_blocksworld/inference.py
@@ -146,6 +146,7 @@ if __name__ == '__main__':
 
     def llama_hf_main(
             llama_path = '/data/haotian/RAP_tune/llama-30B-hf',
+            peft_path = None,
             prompt_path: str = 'examples/rap_blocksworld/prompts/prompt.json',
             data_path: str = 'examples/rap_blocksworld/data/step_4.json',
             disable_log: bool = False,
@@ -155,11 +156,11 @@ if __name__ == '__main__':
             depth_limit: int = 6,
             **kwargs
             ):
-        from reasoners.lm import HFModel ##maybe other transformer models also support
+        from reasoners.lm import HFModel #maybe other transformer models also support, we have not check that
         with open(prompt_path) as f:
             prompt = json.load(f)
         device = torch.device("cuda:0")
-        llama_model = HFModel(llama_path, llama_path, device=device, max_batch_size=1, max_new_tokens=512, quantized="nf4")
+        llama_model = HFModel(llama_path, llama_path, device=device, max_batch_size=1, max_new_tokens=512, quantized="nf4", peft_pth=peft_path)
         rap_bw(llama_model,
                prompt,
                disable_log=disable_log,
@@ -168,4 +169,31 @@ if __name__ == '__main__':
                domain_file=domain_file,
                depth_limit=depth_limit,
                lm_plan_file=lm_plan_file, **kwargs)
-    fire.Fire(llama_hf_main)
+    #for exllama use please refer to https://github.com/turboderp/exllama and put it under /llm-reasoners/
+    def exllama_main(
+            model_dir = '/data/haotian/RAP_tune/Llama-2-70B-GPTQ',
+            lora_dir = None,
+            prompt_path: str = 'examples/rap_blocksworld/prompts/prompt.json',
+            data_path: str = 'examples/rap_blocksworld/data/step_4.json',
+            disable_log: bool = False,
+            config_file: str = "examples/rap_blocksworld/data/bw_config.yaml",
+            domain_file: str = "examples/rap_blocksworld/data/generated_domain.pddl",
+            lm_plan_file: str = 'lm_plan.tmp',
+            depth_limit: int = 6,
+            **kwargs
+            ):
+        from reasoners.lm import ExLlamaModel  ##maybe other transformer models also support
+        with open(prompt_path) as f:
+            prompt = json.load(f)
+        device = torch.device("cuda:0")
+        llama_model = ExLlamaModel(model_dir, lora_dir, device=device, max_batch_size=4, max_new_tokens=1024, max_seq_length=2048)
+        rap_bw(llama_model,
+               prompt,
+               disable_log=disable_log,
+               data_path=data_path,
+               config_file=config_file,
+               domain_file=domain_file,
+               depth_limit=depth_limit,
+               lm_plan_file=lm_plan_file, **kwargs)
+
+    fire.Fire(exllama_main())

--- a/examples/rap_blocksworld/inference.py
+++ b/examples/rap_blocksworld/inference.py
@@ -80,6 +80,7 @@ def rap_bw(base_model: LanguageModel,
 if __name__ == '__main__':
     import os
     import sys
+    sys.path.append('/data/haotian/RAP_tune/llm-reasoners/exllama')
     import json
     import warnings
     import fire

--- a/examples/rap_blocksworld/inference.py
+++ b/examples/rap_blocksworld/inference.py
@@ -144,4 +144,28 @@ if __name__ == '__main__':
                depth_limit=depth_limit,
                lm_plan_file=lm_plan_file, **kwargs)
 
-    fire.Fire(llama_main)
+    def llama_hf_main(
+            llama_path = '/data/haotian/RAP_tune/llama-30B-hf',
+            prompt_path: str = 'examples/rap_blocksworld/prompts/prompt.json',
+            data_path: str = 'examples/rap_blocksworld/data/step_4.json',
+            disable_log: bool = False,
+            config_file: str = "examples/rap_blocksworld/data/bw_config.yaml",
+            domain_file: str = "examples/rap_blocksworld/data/generated_domain.pddl",
+            lm_plan_file: str = 'lm_plan.tmp',
+            depth_limit: int = 6,
+            **kwargs
+            ):
+        from reasoners.lm import HFModel ##maybe other transformer models also support
+        with open(prompt_path) as f:
+            prompt = json.load(f)
+        device = torch.device("cuda:0")
+        llama_model = HFModel(llama_path, llama_path, device=device, max_batch_size=1, max_new_tokens=512, quantized="nf4")
+        rap_bw(llama_model,
+               prompt,
+               disable_log=disable_log,
+               data_path=data_path,
+               config_file=config_file,
+               domain_file=domain_file,
+               depth_limit=depth_limit,
+               lm_plan_file=lm_plan_file, **kwargs)
+    fire.Fire(llama_hf_main)

--- a/examples/rap_blocksworld/world_model.py
+++ b/examples/rap_blocksworld/world_model.py
@@ -88,6 +88,7 @@ class BlocksWorldModel(WorldModel[BWState, BWAction]):
         world_update_prompt = self.prompt[key].format(block_states, action.capitalize() + ".")
         world_output = self.base_model.generate([world_update_prompt],
                                     eos_token_id="\n", hide_input=True, temperature=0).text[0].strip()
+        # print(world_output)
         new_state = utils.apply_change(world_output, block_states)
         return new_state
 

--- a/examples/rap_blocksworld/world_model.py
+++ b/examples/rap_blocksworld/world_model.py
@@ -88,7 +88,6 @@ class BlocksWorldModel(WorldModel[BWState, BWAction]):
         world_update_prompt = self.prompt[key].format(block_states, action.capitalize() + ".")
         world_output = self.base_model.generate([world_update_prompt],
                                     eos_token_id="\n", hide_input=True, temperature=0).text[0].strip()
-        # print(world_output)
         new_state = utils.apply_change(world_output, block_states)
         return new_state
 

--- a/examples/rap_gsm8k/inference.py
+++ b/examples/rap_gsm8k/inference.py
@@ -93,6 +93,7 @@ def rap_gsm8k(base_model: LanguageModel,
 if __name__ == '__main__':
     import os
     import sys
+    sys.path.append('/data/haotian/RAP_tune/llm-reasoners/exllama')
     import json
     import warnings
     import fire

--- a/examples/rap_gsm8k/inference.py
+++ b/examples/rap_gsm8k/inference.py
@@ -157,10 +157,12 @@ if __name__ == '__main__':
                 useful_prompt = "examples/rap_gsm8k/prompts/useful_examples.json",
                 disable_log = False,
                 disable_tqdm = False,
+                quantized = "nf4", # awq, int8, fp4, nf4, None
+                load_awq_pth = None,
                 **kwargs):
         from reasoners.lm import HFModel
         device = torch.device("cuda:0")
-        base_model = HFModel(hf_path, hf_path, device, max_batch_size=batch_size, max_new_tokens=512, peft_pth=peft_path, quantized="awq", load_awq_pth="/data/haotian/RAP_tune/awq_cache/llama-30b-w4-g128.pt")
+        base_model = HFModel(hf_path, hf_path, device, max_batch_size=batch_size, max_new_tokens=512, peft_pth=peft_path, quantized=quantized, load_awq_pth=load_awq_pth)
         with open(interactive_prompt) as f:
             interactive_prompt = json.load(f)
         with open(useful_prompt) as f:
@@ -176,9 +178,9 @@ if __name__ == '__main__':
     
     def main_exllama(
                 model_dir = '/data/haotian/RAP_tune/WizardMath-13B-V1.0-GPTQ',
-                # lora_dir = '/data/haotian/RAP_tune/qlora/output/llama_30b_July_30/checkpoint-213',
                 lora_dir = None,
                 batch_size = 1,
+                mem_map = None,
                 interactive_prompt = "examples/rap_gsm8k/prompts/interactive_examples.json",
                 useful_prompt = "examples/rap_gsm8k/prompts/useful_examples.json",
                 disable_log = False,
@@ -186,7 +188,7 @@ if __name__ == '__main__':
                 **kwargs):
         from reasoners.lm import ExLlamaModel
         device = torch.device("cuda:0")
-        base_model = ExLlamaModel(model_dir, lora_dir, device, max_batch_size=batch_size, max_new_tokens=400, max_seq_length=2048)
+        base_model = ExLlamaModel(model_dir, lora_dir, device, max_batch_size=batch_size, max_new_tokens=400, max_seq_length=2048, mem_map=mem_map)#please set mem_map if you need model parallelism, e.g. mem_map = [16,22] with 2 GPUs
         with open(interactive_prompt) as f:
             interactive_prompt = json.load(f)
         with open(useful_prompt) as f:
@@ -199,4 +201,4 @@ if __name__ == '__main__':
                   disable_tqdm=disable_tqdm or local_rank != 0,
                   **kwargs)
         
-    fire.Fire(main_exllama())
+    fire.Fire(main_hf)

--- a/examples/rap_gsm8k/inference.py
+++ b/examples/rap_gsm8k/inference.py
@@ -170,10 +170,10 @@ if __name__ == '__main__':
     
     
     def main_exllama(
-                model_dir = '/data/haotian/RAP_tune/Llama-2-70B-GPTQ',
+                model_dir = '/data/haotian/RAP_tune/WizardMath-13B-V1.0-GPTQ',
                 # lora_dir = '/data/haotian/RAP_tune/qlora/output/llama_30b_July_30/checkpoint-213',
                 lora_dir = None,
-                batch_size = 4,
+                batch_size = 1,
                 interactive_prompt = "examples/rap_gsm8k/prompts/interactive_examples.json",
                 useful_prompt = "examples/rap_gsm8k/prompts/useful_examples.json",
                 disable_log = False,
@@ -194,4 +194,4 @@ if __name__ == '__main__':
                   disable_tqdm=disable_tqdm or local_rank != 0,
                   **kwargs)
         
-    fire.Fire(main_hf())
+    fire.Fire(main_exllama())

--- a/examples/rap_gsm8k/inference.py
+++ b/examples/rap_gsm8k/inference.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
                 disable_tqdm = False,
                 **kwargs):
         from reasoners.lm import HFModel
-        device = torch.device("cuda")
+        device = torch.device("cuda:0")
         base_model = HFModel(hf_path, hf_path, device, max_batch_size=batch_size, max_new_tokens=512, peft_pth=peft_path, quantized="awq", load_awq_pth="/data/haotian/RAP_tune/awq_cache/llama-30b-w4-g128.pt")
         with open(interactive_prompt) as f:
             interactive_prompt = json.load(f)

--- a/examples/rap_gsm8k/inference.py
+++ b/examples/rap_gsm8k/inference.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
              llama_ckpt: str = llama_ckpts,
              llama_size: str = '13B',
              llama_cpp_path: str = None,
-             batch_size: int = 2,
+             batch_size: int = 1,
              interactive_prompt: str = 'examples/rap_gsm8k/prompts/interactive_examples.json',
              useful_prompt: str = 'examples/rap_gsm8k/prompts/useful_examples.json',
              disable_log: bool = False,
@@ -145,5 +145,26 @@ if __name__ == '__main__':
                   disable_tqdm=disable_tqdm or local_rank != 0,
                   **kwargs)
 
-
-    fire.Fire(main)
+    def main_hf(hf_path = "/data/haotian/RAP_tune/llama-30B-hf",
+                batch_size = 1,
+                interactive_prompt = "examples/rap_gsm8k/prompts/interactive_examples.json",
+                useful_prompt = "examples/rap_gsm8k/prompts/useful_examples.json",
+                disable_log = False,
+                disable_tqdm = False,
+                **kwargs):
+        from reasoners.lm import HFModel
+        device = torch.device("cuda")
+        base_model = HFModel(hf_path, hf_path, device, max_batch_size=batch_size, max_new_tokens=400, quantized="nf4")
+        with open(interactive_prompt) as f:
+            interactive_prompt = json.load(f)
+        with open(useful_prompt) as f:
+            useful_prompt = json.load(f)
+        rap_gsm8k(base_model=base_model,
+                  interactive_prompt=interactive_prompt,
+                  useful_prompt=useful_prompt,
+                  batch_size=batch_size,
+                  disable_log=disable_log or local_rank != 0,
+                  disable_tqdm=disable_tqdm or local_rank != 0,
+                  **kwargs)
+        
+    fire.Fire(main_hf)

--- a/examples/rap_gsm8k/search_config.py
+++ b/examples/rap_gsm8k/search_config.py
@@ -22,7 +22,7 @@ class GSM8kConfig(SearchConfig):
                  prompt: dict,
                  useful_prompt: dict,
                  n_actions=4,
-                 batch_size=2,
+                 batch_size=1,
                  temperature=0.8,
                  reward_alpha=0.5,
                  reward_confidence_default=0.8,
@@ -69,6 +69,7 @@ class GSM8kConfig(SearchConfig):
         outputs = []
         for idx in range(0, n_actions, self.batch_size):
             n_samples = min(n_actions - idx, self.batch_size)
+            # print(n_samples)
             outputs += self.base_model.generate([model_input] * n_samples,
                                                 hide_input=True,
                                                 do_sample=True,

--- a/examples/rap_gsm8k/search_config.py
+++ b/examples/rap_gsm8k/search_config.py
@@ -69,7 +69,6 @@ class GSM8kConfig(SearchConfig):
         outputs = []
         for idx in range(0, n_actions, self.batch_size):
             n_samples = min(n_actions - idx, self.batch_size)
-            # print(n_samples)
             outputs += self.base_model.generate([model_input] * n_samples,
                                                 hide_input=True,
                                                 do_sample=True,

--- a/reasoners/lm/__init__.py
+++ b/reasoners/lm/__init__.py
@@ -1,4 +1,6 @@
+from sympy import im
 from .hf_model import *
 from .llama_model import *
 from .llama_cpp_model import *
 from .openai_model import *
+from .exllama_model import *

--- a/reasoners/lm/exllama_model.py
+++ b/reasoners/lm/exllama_model.py
@@ -1,0 +1,22 @@
+from .. import LanguageModel,GenerateOutput
+from exllama.model import ExLlama, ExLlamaCache, ExLlamaConfig
+from exllama.tokenizer import ExLlamaTokenizer
+from exllama.lora import ExLlamaLora
+import torch
+from typing import Tuple, Union, Optional
+import warnings
+import copy
+import sys
+import numpy as np
+import optimum
+import os
+from optimum.bettertransformer import BetterTransformer
+from tqdm import tqdm
+
+class ExLlamaModel(LanguageModel):
+    def __init__(self, model_dir, tokenizer_dir, device, max_batch_size, max_new_tokens):
+        super().__init__()
+        tokenizer_path = os.path.join(model_dir, "tokenizer.model")
+        model_config_path = os.path.join(model_dir, "config.json")
+        st_pattern = os.path.join(model_dir, "*.safetensors")
+        

--- a/reasoners/lm/exllama_model.py
+++ b/reasoners/lm/exllama_model.py
@@ -1,3 +1,7 @@
+import os
+import sys
+exllama_pth = os.path.abspath(os.path.join(os.path.join(os.path.join(__file__, os.pardir), os.pardir), os.pardir)) + '/exllama'
+sys.path.append(exllama_pth)
 from exllama import model
 from exllama.generator import ExLlamaGenerator
 from .. import LanguageModel,GenerateOutput
@@ -9,12 +13,12 @@ from typing import Tuple, Union, Optional
 import warnings
 import numpy as np
 import random
-import os
+
 from tqdm import tqdm
 import glob
 import time
 class ExLlamaModel(LanguageModel):
-    def __init__(self, model_dir, lora_dir, device, max_batch_size, max_new_tokens, max_seq_length):
+    def __init__(self, model_dir, lora_dir, device, max_batch_size, max_new_tokens, max_seq_length, mem_map:list[int]=None):
         """
         Initializes an ExLlamaModel instance.
 
@@ -25,7 +29,7 @@ class ExLlamaModel(LanguageModel):
             max_batch_size (int): Maximum batch size for inference.
             max_new_tokens (int): Maximum number of new tokens to generate during inference.
             max_seq_length (int): Maximum sequence length for input text.
-
+            mem_map (list[int]): List of integers specifying the memory map for the model (optional).
         Returns:
             None
         """
@@ -51,7 +55,10 @@ class ExLlamaModel(LanguageModel):
         self.config = ExLlamaConfig(model_config_path)               # create config from config.json
         self.config.model_path = model_path                          # supply path to model weights file
         self.config.max_seq_length = max_seq_length                  # set max sequence length
-        self.config.auto_map = [18,22]
+        if mem_map is not None:
+            self.config.auto_map = mem_map
+            warnings.warn("mem_map is None, if you want model parallelism, please set mem_map like [16,22] for 2 GPUs")
+        
         self.model = ExLlama(self.config)                                 # create ExLlama instance and load the weights
         self.tokenizer = ExLlamaTokenizer(tokenizer_path)            # create tokenizer from tokenizer model file
 

--- a/reasoners/lm/exllama_model.py
+++ b/reasoners/lm/exllama_model.py
@@ -15,6 +15,20 @@ import glob
 import time
 class ExLlamaModel(LanguageModel):
     def __init__(self, model_dir, lora_dir, device, max_batch_size, max_new_tokens, max_seq_length):
+        """
+        Initializes an ExLlamaModel instance.
+
+        Args:
+            model_dir (str): Path to the directory containing the ExLlama model files.
+            lora_dir (str): Path to the directory containing the LoRA adapter files (optional).
+            device (str): Device to use for inference (e.g. "cpu", "cuda").
+            max_batch_size (int): Maximum batch size for inference.
+            max_new_tokens (int): Maximum number of new tokens to generate during inference.
+            max_seq_length (int): Maximum sequence length for input text.
+
+        Returns:
+            None
+        """
         super().__init__()
         torch.cuda._lazy_init()
 
@@ -112,7 +126,7 @@ class ExLlamaModel(LanguageModel):
                         decoded[i] = decoded[i].split(eos_token_id)[0]
             log_prob = None
             if output_log_probs:
-                warnings.warn("output_log_probs is temporarily not supported by ExLlamaModel. Please refere to exllama's code")
+                warnings.warn("output_log_probs is temporarily not supported now by ExLlamaModel. Please refere to exllama's code")
             decoded_list.extend(decoded)
         return GenerateOutput(decoded_list, log_prob_list)
 

--- a/reasoners/lm/exllama_model.py
+++ b/reasoners/lm/exllama_model.py
@@ -93,7 +93,7 @@ class ExLlamaModel(LanguageModel):
             max_new_tokens = self.max_new_tokens
         if eos_token_id is not None:
             warnings.warn("eos_token_id is not supported by ExLlamaModel. Use disallow_tokens instead. Here may lead to bug and please check. We just use split when eos isinstance(str)")
-        if do_sample is False:
+        if do_sample is False or temperature <= 0.0:
             warnings.warn("do_sample is defaultly set to False, we will set temp=1.0 and top-k = 1 for Exllama")
             temperature = 1.0
             top_k = 1

--- a/reasoners/lm/exllama_model.py
+++ b/reasoners/lm/exllama_model.py
@@ -1,3 +1,5 @@
+from exllama import model
+from exllama.generator import ExLlamaGenerator
 from .. import LanguageModel,GenerateOutput
 from exllama.model import ExLlama, ExLlamaCache, ExLlamaConfig
 from exllama.tokenizer import ExLlamaTokenizer
@@ -5,18 +7,183 @@ from exllama.lora import ExLlamaLora
 import torch
 from typing import Tuple, Union, Optional
 import warnings
-import copy
-import sys
 import numpy as np
-import optimum
+import random
 import os
-from optimum.bettertransformer import BetterTransformer
 from tqdm import tqdm
-
+import glob
+import time
 class ExLlamaModel(LanguageModel):
-    def __init__(self, model_dir, tokenizer_dir, device, max_batch_size, max_new_tokens):
+    def __init__(self, model_dir, lora_dir, device, max_batch_size, max_new_tokens, max_seq_length):
         super().__init__()
+        torch.cuda._lazy_init()
+
+        # set random seed
+        torch.set_grad_enabled(False)
+        random.seed(0)
+        np.random.seed(0)
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        torch.backends.cudnn.deterministic = True
         tokenizer_path = os.path.join(model_dir, "tokenizer.model")
         model_config_path = os.path.join(model_dir, "config.json")
         st_pattern = os.path.join(model_dir, "*.safetensors")
+        model_path = glob.glob(st_pattern)[0]
+
+
+
+        # Create config, model, tokenizer and generator
+
+        self.config = ExLlamaConfig(model_config_path)               # create config from config.json
+        self.config.model_path = model_path                          # supply path to model weights file
+        self.config.max_seq_length = max_seq_length                  # set max sequence length
+        self.config.auto_map = [18,22]
+        self.model = ExLlama(self.config)                                 # create ExLlama instance and load the weights
+        self.tokenizer = ExLlamaTokenizer(tokenizer_path)            # create tokenizer from tokenizer model file
+
+        self.cache = ExLlamaCache(self.model,max_batch_size)                             # create cache for inference
+        self.generator = ExLlamaGenerator(self.model, self.tokenizer, self.cache)   # create generator
+        self.lora = None
+
+        # Load LoRA
+        if lora_dir is not None:
+            lora_config_path = os.path.join(lora_dir, "adapter_config.json")
+            lora_path = os.path.join(lora_dir, "adapter_model.bin")
+            self.lora = ExLlamaLora(self.model, lora_config_path, lora_path)
+            self.generator.lora = self.lora
+
+        self.device = device
+        self.max_batch_size = max_batch_size
+        self.max_new_tokens = max_new_tokens
+        self.max_seq_length = max_seq_length
+    def generate(
+            self,
+            inputs: list[str],
+            max_length: Optional[int] = None,
+            max_new_tokens: Optional[int] = None,
+            do_sample: bool = False,
+            temperature: float = 1.0,
+            top_k: int = 50,
+            top_p: float = 1.0,
+            num_return_sequences: int = 1,
+            eos_token_id: Union[None, str, int, list[str, int]] = None,
+            hide_input: bool = True,
+            output_log_probs: bool = False,
+            **kwargs,
+        ) -> GenerateOutput:
+
+        if max_length is not None:
+            warnings.warn("max_length is not supported by ExLlamaModel for generation. Use max_new_tokens instead.")
+        if max_new_tokens is None:
+            warnings.warn("max_new_tokens is not set, we will use the default value: {}".format(self.max_new_tokens))
+            max_new_tokens = self.max_new_tokens
+        if eos_token_id is not None:
+            warnings.warn("eos_token_id is not supported by ExLlamaModel. Use disallow_tokens instead. Here may lead to bug and please check. We just use split when eos isinstance(str)")
+        if do_sample is False:
+            warnings.warn("do_sample is defaultly set to False, we will set temp=1.0 and top-k = 1 for Exllama")
+            temperature = 1.0
+            top_k = 1
+
+        self.generator.settings.token_repetition_penalty_max = 1.0
+        self.generator.settings.temperature = temperature
+        self.generator.settings.top_p = top_p
+        self.generator.settings.top_k = top_k
+        self.generator.settings.typical = 0.0
+
+        if num_return_sequences > 1:
+            assert len(inputs) == 1, "num_return_sequences > 1 is not supported for batched inputs"
+            inputs = inputs * num_return_sequences
+        
+        decoded_list = []
+        log_prob_list = None
+        for start in range(0, len(inputs), self.max_batch_size):
+            end = min(start + self.max_batch_size, len(inputs))
+            with torch.inference_mode():
+                p_time = time.time()
+                decoded = self.generator.generate_simple(inputs[start:end], max_new_tokens=self.max_new_tokens)
+                f_time = time.time()
+                print(f"Time for generating {self.max_new_tokens}*{end-start} examples: {f_time-p_time}, speed: {self.max_new_tokens*(end-start)/(f_time-p_time)} t/s")
+            if not isinstance(decoded, list):
+                decoded = [decoded]
+            if hide_input:
+                for i in range(end-start):
+                    decoded[i] = decoded[i][len(inputs[start+i]):]
+                    if isinstance(eos_token_id, str):
+                        decoded[i] = decoded[i].split(eos_token_id)[0]
+            log_prob = None
+            if output_log_probs:
+                warnings.warn("output_log_probs is temporarily not supported by ExLlamaModel. Please refere to exllama's code")
+            decoded_list.extend(decoded)
+        return GenerateOutput(decoded_list, log_prob_list)
+
+    @torch.no_grad()
+    def get_next_token_logits(
+        self,
+        prompt: Union[str, list[str]],
+        candidates: Union[list[str], list[list[str]]]) -> list[np.ndarray]:
+        if isinstance(prompt, str):
+            prompt = [prompt]
+        if isinstance(candidates[0], str):
+            candidates = [candidates] * len(prompt)
+        cand_tokens = []
+        for candidate in candidates:
+            cand_tokens.append([])
+            for cand in candidate:
+                token = self.tokenizer.encode(cand, add_bos=False, add_eos=False)
+                if len(token) != 1:
+                    warnings.warn(f'candidate {cand} corresponds to {len(token)} instead of 1')
+                cand_tokens[-1].append(token[1].item() if len(token) > 1 else token[0].item())
+        
+        bsz = len(prompt)
+        assert bsz <= self.max_batch_size, (bsz, self.max_batch_size)
+
+        tokens, mask = self.tokenizer.encode(prompt, return_mask=True, add_bos=True, add_eos=False)
+        p_time = time.time()
+        with torch.no_grad():
+            self.cache.current_seq_len = 0
+            all_logits = self.model.forward(
+                tokens,
+                self.cache,
+                last_id_only = True,
+                preprocess_only = False,
+                lora = self.lora,
+                output_device = self.device,
+                input_mask = mask
+            ).squeeze(1)
+        f_time = time.time()
+        assert all_logits.shape[0] == bsz, (all_logits.shape[0], bsz)
+        print(f"Time for forwarding {self.max_new_tokens} examples: {f_time-p_time}, speed: {self.max_new_tokens/(f_time-p_time)} t/s")
+        logits = []
+        for case_logits, cand in zip(all_logits, cand_tokens):
+
+            logits.append(case_logits[cand].cpu().numpy())
+        return logits
+
+    @torch.no_grad()
+    def get_loglikelihood(self, prefix: str, contents: list[str], **kwargs) -> np.ndarray:
+        bsz = len(contents)
+        assert bsz <= self.max_batch_size, (bsz, self.max_batch_size)
+        prefix_tokens = self.tokenizer.encode(prefix, add_bos=True, add_eos=False).squeeze(0)
+        prompts_tokens, mask = self.tokenizer.encode(contents, return_mask=True, add_bos=True, add_eos=False)
+        for prompt_tokens in prompts_tokens:
+            assert torch.all(prompt_tokens[:len(prefix_tokens)] == prefix_tokens)
+        tokens = prompts_tokens
+        with torch.no_grad():
+            self.cache.current_seq_len = 0
+            logits = self.model.forward(
+                tokens,
+                self.cache,
+                last_id_only = False,
+                preprocess_only = False,
+                lora = self.lora,
+                output_device = self.device,
+                input_mask = mask
+            )
+        acc_probs = torch.zeros(bsz).to(self.device)
+        for i in range(len(prefix_tokens), tokens.shape[1]):
+            probs = torch.softmax(logits[:, i - 1, :], dim=-1)
+            for j in range(bsz):
+                if tokens[j, i] != self.tokenizer.pad_token_id:
+                    acc_probs[j] += torch.log(probs[j, tokens[j, i]])
+        return acc_probs.cpu().numpy()
         

--- a/reasoners/lm/hf_model.py
+++ b/reasoners/lm/hf_model.py
@@ -10,11 +10,11 @@ import sys
 import numpy as np
 import optimum
 from optimum.bettertransformer import BetterTransformer
-#for awq quantization, please refer to https://github.com/mit-han-lab/llm-awq
-from awq.quantize.quantizer import pseudo_quantize_model_weight, real_quantize_model_weight
-from awq.utils.utils import simple_dispatch_model
-from awq.quantize.pre_quant import apply_awq
-from awq.quantize.quantizer import real_quantize_model_weight
+#for awq quantization, please refer to https://github.com/mit-han-lab/llm-awq to build env
+# from awq.quantize.quantizer import pseudo_quantize_model_weight, real_quantize_model_weight
+# from awq.utils.utils import simple_dispatch_model
+# from awq.quantize.pre_quant import apply_awq
+# from awq.quantize.quantizer import real_quantize_model_weight
 from accelerate import init_empty_weights, load_checkpoint_and_dispatch, infer_auto_device_map, load_checkpoint_in_model, dispatch_model
 class HFModel(LanguageModel):
     def __init__(self, model_pth, tokenizer_pth, device, max_batch_size=1, max_new_tokens=None, max_length=2048, quantized=None, peft_pth=None, load_awq_pth=None):
@@ -35,7 +35,7 @@ class HFModel(LanguageModel):
         """
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_pth, lagacy=False)
 
-        if quantized == "8bit":
+        if quantized == "int8":
             self.model = LlamaForCausalLM.from_pretrained(
                 model_pth,
                 load_in_8bit=True,
@@ -145,7 +145,6 @@ class HFModel(LanguageModel):
             bos_token_id=self.tokenizer.bos_token_id,
             eos_token_id=eos_token_id,
             do_sample = do_sample,
-            early_stopping=True,
             top_k=top_k,
             top_p=top_p,
         )
@@ -158,7 +157,6 @@ class HFModel(LanguageModel):
             bos_token_id=self.tokenizer.bos_token_id,
             eos_token_id=eos_token_id,
             do_sample = do_sample,
-            early_stopping=True,
             top_k=top_k,
             top_p=top_p,
         )

--- a/reasoners/lm/hf_model.py
+++ b/reasoners/lm/hf_model.py
@@ -1,1 +1,217 @@
-from .. import LanguageModel
+from .. import LanguageModel,GenerateOutput
+from transformers import LlamaForCausalLM, AutoTokenizer, GenerationConfig, BitsAndBytesConfig
+import torch
+from peft import PeftModel
+from typing import Tuple, Union, Optional
+import warnings
+import copy
+import sys
+import numpy as np
+import optimum
+from optimum.bettertransformer import BetterTransformer
+class HFModel(LanguageModel):
+    def __init__(self, model_pth, tokenizer_pth, device, max_batch_size=1, max_new_tokens=256, quantized=None, peft_pth=None):
+        super().__init__()
+        #quantized is a string, can be None, "8bit", "nf4", "fp4" 
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_pth, lagacy=False)
+
+        if quantized == "8bit":
+            self.model = LlamaForCausalLM.from_pretrained(
+                model_pth,
+                load_in_8bit=True,
+                torch_dtype=torch.float16,
+                device_map="auto",                                    
+            )
+        elif quantized == "nf4" or quantized  == "fp4":
+            bnb_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type=quantized,
+                bnb_4bit_compute_dtype=torch.bfloat16,
+            )
+
+            print("quantizing.............................")
+
+            self.model = LlamaForCausalLM.from_pretrained(
+                model_pth,
+                quantization_config=bnb_config,
+                device_map="auto",
+            )
+        else:
+            self.model = LlamaForCausalLM.from_pretrained(
+                model_pth,
+                device_map="auto",
+            )
+        if peft_pth is not None:
+            self.model = PeftModel.from_pretrained(
+                self.model, 
+                peft_pth,
+                torch_dtype=torch.float16
+            )
+        
+        self.max_new_tokens = max_new_tokens
+        self.max_batch_size = max_batch_size
+        self.device = device
+        self.model = BetterTransformer.transform(self.model)
+        self.model.eval()
+        # for old llama tokenizer's config, below is necessary
+        self.model.config.pad_token_id = self.tokenizer.pad_token_id = 0  # unk
+        self.model.config.bos_token_id = 1
+        self.model.config.eos_token_id = 2
+        # if torch.__version__ >= "2" and sys.platform != "win32":#need to figure out this line
+        #     self.model = torch.compile(self.model) ###make the faketensor bug
+    def generate(
+            self,
+            inputs: list[str],
+            max_length: Optional[int] = 20,
+            max_new_tokens: Optional[int] = None,
+            do_sample: bool = False,
+            temperature: float = 1.0,
+            top_k: int = 50,
+            top_p: float = 1.0,
+            num_return_sequences: int = 1,
+            eos_token_id: Union[None, str, int, list[str, int]] = None,
+            hide_input: bool = True,
+            output_log_probs: bool = False,
+            **kwargs,
+        ) -> GenerateOutput:
+
+        # unify eos_token
+        # if max_length is None:
+        #     max_length = self.max_seq_len  # use LLaMA's max length if not set
+        if max_new_tokens is None:
+            max_new_tokens = self.max_new_tokens
+        eos_token_id_input = copy.deepcopy(eos_token_id)
+        eos_token_id = []
+
+        if eos_token_id_input is not None:
+            if not isinstance(eos_token_id_input, list):
+                eos_token_id_input = [eos_token_id_input]
+            for token in eos_token_id_input:
+                if isinstance(token, str):
+                    tokenized = self.tokenizer.encode(token, add_special_tokens=False)
+                    if len(tokenized) != 1:
+                        warnings.warn(f'the eos_token {repr(token)} is encoded into {tokenized} with length != 1, '
+                                    f'using {tokenized[-1]} as the eos_token_id')
+                    token = tokenized[-1]
+                if isinstance(token, int):
+                    eos_token_id.append(token)
+                else:
+                    warnings.warn(f'the eos_token {repr(token)} is neither str nor int, which is ignored')
+        eos_token_id.append(self.tokenizer.eos_token_id)
+        generation_config = GenerationConfig(
+            max_length=max_length,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            pad_token_id=self.tokenizer.pad_token_id,
+            bos_token_id=self.tokenizer.bos_token_id,
+            eos_token_id=eos_token_id,
+            do_sample = do_sample,
+            early_stopping=True,
+            top_k=top_k,
+            top_p=top_p,
+        )
+#############
+        # print(torch.cuda.memory_summary("cuda:0"))
+        # print(torch.cuda.memory_summary("cuda:1"))
+        # print(torch.cuda.memory_summary("cuda:2"))
+        # print(torch.cuda.memory_summary("cuda:3"))
+        # print(len(inputs))
+        
+        if num_return_sequences > 1:
+            assert len(inputs) == 1, 'num_return_sequences > 1 is not supported for multiple inputs'
+            inputs = inputs * num_return_sequences
+        decoded_list = []
+        log_prob_list = []
+        for start in range(0, len(inputs), self.max_batch_size):
+            end = min(start + self.max_batch_size, len(inputs))
+            # print(end-start)
+            encoded_inputs = self.tokenizer(inputs[start:end], return_tensors='pt', padding=True).to(self.device)
+            with torch.inference_mode():
+                generation_output = self.model.generate(
+                    **encoded_inputs,
+                    generation_config=generation_config,
+                    output_scores=output_log_probs,
+                    return_dict_in_generate=True,
+                )
+            decoded = self.tokenizer.batch_decode(generation_output.sequences, skip_special_tokens=True)
+            if hide_input:
+                for i in range(len(inputs)):
+                    decoded[i] = decoded[i][len(inputs[i]):]
+            log_prob = None
+            if output_log_probs:
+                log_prob = generation_output.sequences_scores
+                log_prob_list.extend(log_prob)
+            decoded_list.extend(decoded)
+        if output_log_probs:
+            log_prob_list = None
+
+        return GenerateOutput(decoded_list, log_prob_list)
+
+    @torch.no_grad()
+    def get_next_token_logits(
+        self,
+        prompt: Union[str, list[str]],
+        candidates: Union[list[str], list[list[str]]]) -> list[np.ndarray]:
+        if isinstance(prompt, str):
+            prompt = [prompt]
+        if isinstance(candidates[0], str):
+            candidates = [candidates] * len(prompt)
+        cand_tokens = []
+        for candidate in candidates:
+            cand_tokens.append([])
+            for cand in candidate:
+                token = self.tokenizer.encode(cand, add_special_tokens=False)
+                if len(token) != 1:
+                    warnings.warn(f'candidate {cand} corresponds to {len(token)} instead of 1')
+                cand_tokens[-1].append(token[1] if len(token) > 1 else token[0])
+        
+
+        bsz = len(prompt)
+        assert bsz <= self.max_batch_size, (bsz, self.max_batch_size)
+
+        tokens = self.tokenizer(prompt, return_tensors='pt', padding=True).to(self.device)
+        
+        # all_logits = self.model.generate(**tokens,output_scores=True, return_dict_in_generate=True, max_new_tokens=1).scores[0]
+        # all_logits = self.model.generate(**tokens,return_dict=True)
+        with torch.no_grad():
+            all_logits = self.model(**tokens, return_dict=True).logits[:,-1,:].squeeze(1)
+        # print(all_logits)
+
+        logits = []
+        for case_logits, cand in zip(all_logits, cand_tokens):
+            # print(case_logits[cand])
+            logits.append(case_logits[cand].cpu().numpy())
+        # print(logits)
+        return logits
+    
+    @torch.no_grad()
+    def get_loglikelihood(self, prefix: str, contents: list[str], **kwargs) -> np.ndarray:
+        bsz = len(contents)
+        assert bsz <= self.max_batch_size, (bsz, self.max_batch_size)
+        prompts_tokens = self.tokenizer(contents, return_tensors='pt',add_special_tokens=False, padding=True).to(self.device)
+        prefix_tokens = self.tokenizer(prefix, return_tensors='pt',add_special_tokens=False, padding=True).input_ids[0].to(self.device)
+        
+        for prompt_tokens in prompts_tokens.input_ids:
+            # print(prompt_tokens)
+            # print(prefix_tokens)
+            # print(len(prompt_tokens), len(prefix_tokens))
+            assert torch.all(prompt_tokens[: len(prefix_tokens)] == prefix_tokens), (prompt_tokens, prefix_tokens)
+
+        tokens = prompts_tokens
+        logits = self.model(**tokens, return_dict=True).logits
+        tokens = prompts_tokens.input_ids
+        acc_probs = torch.zeros(bsz).to(self.device)
+        for i in range(len(prefix_tokens), tokens.shape[1]):
+            probs = torch.softmax(logits[:, i-1, :], dim=-1)
+            for j in range(bsz):
+                if tokens[j, i] != self.tokenizer.pad_token_id:
+                    acc_probs[j] += torch.log(probs[j, tokens[j, i]])
+        return acc_probs.cpu().numpy()
+        
+
+
+
+
+        
+

--- a/reasoners/lm/hf_model.py
+++ b/reasoners/lm/hf_model.py
@@ -19,7 +19,20 @@ from accelerate import init_empty_weights, load_checkpoint_and_dispatch, infer_a
 class HFModel(LanguageModel):
     def __init__(self, model_pth, tokenizer_pth, device, max_batch_size=1, max_new_tokens=None, max_length=2048, quantized=None, peft_pth=None, load_awq_pth=None):
         super().__init__()
-        #quantized is a string, can be None, "8bit", "nf4", "fp4" 
+        """
+        Initializes a new instance of the `HFModel` class.
+
+        Args:
+            model_pth (str): The path to the directory containing the pre-trained model.
+            tokenizer_pth (str): The path to the directory containing the pre-trained tokenizer.
+            device (str): The device to use for running the model (e.g. "cpu", "cuda").
+            max_batch_size (int, optional): The maximum batch size to use for inference. Defaults to 1.
+            max_new_tokens (int, optional): The maximum number of new tokens to generate during inference. Defaults to None.
+            max_length (int, optional): The maximum length of the input sequence. Defaults to 2048.
+            quantized (str, optional): The type of quantization to use for the model. Can be "8bit", "nf4", "fp4", or "awq". Defaults to None.
+            peft_pth (str, optional): The path to the directory containing the pre-trained PEFT model. Defaults to None.
+            load_awq_pth (str, optional): The path to the directory containing the pre-trained AWQ model. Defaults to None.
+        """
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_pth, lagacy=False)
 
         if quantized == "8bit":

--- a/reasoners/lm/llama_model.py
+++ b/reasoners/lm/llama_model.py
@@ -240,7 +240,6 @@ class LLaMAModel(LanguageModel):
         prompts_tokens = [self.tokenizer.encode(x, bos=True, eos=False) for x in contents]
 
         for prompt_tokens in prompts_tokens:
-            # print("prompt length:", len(prompt_tokens))
             assert prompt_tokens[:len(prefix_tokens)] == prefix_tokens
 
         max_prompt_size = max([len(t) for t in prompts_tokens])

--- a/reasoners/lm/llama_model.py
+++ b/reasoners/lm/llama_model.py
@@ -241,7 +241,7 @@ class LLaMAModel(LanguageModel):
         # print("prefix length:", len(prefix_tokens))
         for prompt_tokens in prompts_tokens:
             # print("prompt length:", len(prompt_tokens))
-            assert prompt_tokens[: len(prefix_tokens)] == prefix_tokens
+            assert prompt_tokens[:len(prefix_tokens)] == prefix_tokens
 
         max_prompt_size = max([len(t) for t in prompts_tokens])
         total_len = max_prompt_size

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,10 @@ requests~=2.31.0
 PyYAML~=6.0
 tarski~=0.8.2
 setuptools~=67.8.0
+#blocksworld
+tarski
+#quantization
+peft~=0.5.0
+optimum
+ninja~=1.11.1
+bitsandbytes~=0.41.1

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ setup(name='reasoners',
                         'transformers',
                         'sentencepiece',
                         'openai',
+                        'tarski',
+                        'peft',
+                        'optimum',
+                        'ninja',
+                        'bitsandbytes',
                         'llama1@git+https://github.com/AegeanYan/llama@llama_v1',#llama 2 have some alias problem so you may need to clone the forked llama1 at private repo. please check the setup.py
                         'llama@git+https://github.com/facebookresearch/llama@main',
                         'fairscale'])


### PR DESCRIPTION
Now the llm-reasoners can support hf-llama and exllama style model. For hf, we support nf4, 8-bit, fp4, awq quantization. for exllama, i think we temporarily do not support log_prob in `generate()` method. And they now both support 70B llama-2 on 2x3090 for slow inference.